### PR TITLE
Add Typescript for type linting JS code

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ globally just leave out `./run.sh`.
 - `cd <here>`
 - `./run.sh npm i` to install all dependencies
 - `./run.sh npm test` to run all the tests
+- `./run.sh npm run typecheck` to verify that all types are correct
 - develop ...
 
 ## Releasing

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node -r esm
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import { parseChangelog, LINE_START_FOR_TODO } from '../src/parse-changelog.js';
 
 const WORKING_DIR = process.cwd();

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,12 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
+    },
+    "typescript": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/node": {
+      "version": "13.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+      "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ==",
+      "dev": true
+    },
     "esm": {
       "version": "3.2.25",
       "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "kavun `bash -c 'ls src/*.spec.js'` --reporter=minimal",
     "releasable": "npm test && node -r esm ./src/parse-changelog.js",
-    "release": "npm version major"
+    "release": "npm version major",
+    "typecheck": "tsc"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "kavun `bash -c 'ls src/*.spec.js'` --reporter=minimal",
     "releasable": "npm test && node -r esm ./src/parse-changelog.js",
     "release": "npm version major",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "dev:typecheck": "npm run typecheck -- --watch"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/wolframkriesing/to-do-list-checker#readme",
   "devDependencies": {
+    "@types/node": "^13.9.1",
     "kavun": "^3.0.0",
     "typescript": "^3.8.3"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "homepage": "https://github.com/wolframkriesing/to-do-list-checker#readme",
   "devDependencies": {
-    "kavun": "^3.0.0"
+    "kavun": "^3.0.0",
+    "typescript": "^3.8.3"
   },
   "dependencies": {
     "esm": "^3.2.25"

--- a/src/parse-changelog.js
+++ b/src/parse-changelog.js
@@ -1,17 +1,21 @@
 export const LINE_START_FOR_NEW_VERSION = '# version ';
 export const LINE_START_FOR_TODO = '- [ ]';
 
+/**
+ * @param {string} content
+ * @returns {string[]}
+ */
 const todoItems = (content) => {
   return content
     .split('\n')
     .filter(line => line.startsWith(LINE_START_FOR_TODO))
     .map(line => line.substr(LINE_START_FOR_TODO.length + 1))
-    ;
+  ;
 };
 
 /**
  * @param {string} changelogContent
- * @returns {{version: number, items: []}}
+ * @returns {{version: number, items: string[]}}
  */
 export const parseChangelog = (changelogContent) => {
   const hasContent = !!changelogContent.trim();

--- a/src/parse-changelog.js
+++ b/src/parse-changelog.js
@@ -23,6 +23,6 @@ export const parseChangelog = (changelogContent) => {
   }
   const versions = changelogContent.split(LINE_START_FOR_NEW_VERSION);
   const firstVersionParagraph = versions[1];
-  const version = firstVersionParagraph.split('\n')[0];
+  const version = Number.parseInt(firstVersionParagraph.split('\n')[0], 10);
   return { version, items: todoItems(firstVersionParagraph) };
 };

--- a/src/parse-changelog.js
+++ b/src/parse-changelog.js
@@ -9,6 +9,10 @@ const todoItems = (content) => {
     ;
 };
 
+/**
+ * @param {string} changelogContent
+ * @returns {{version: number, items: []}}
+ */
 export const parseChangelog = (changelogContent) => {
   const hasContent = !!changelogContent.trim();
   if (!hasContent) {

--- a/src/parse-changelog.spec.js
+++ b/src/parse-changelog.spec.js
@@ -1,5 +1,5 @@
 import {describe, it} from 'kavun';
-import assert from 'assert';
+import * as assert from 'assert';
 import { parseChangelog } from './parse-changelog.js';
 
 describe('Parse a CHANGELOG.md', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,10 @@
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,
+    "noImplicitAny": true,
     "noImplicitReturns": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "strict": true
   },
   "include": ["**/*.js"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,
-    "noEmit": true
+    "noEmit": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true
   },
   "include": ["src/*.js"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,5 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true
   },
-  "include": ["src/*.js"]
+  "include": ["**/*.js"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "noEmit": true
+  },
+  "include": ["src/*.js"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "noUnusedLocals": true,
     "strict": true
   },
-  "include": ["**/*.js"]
+  "include": ["typings", "**/*.js"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "allowJs": true,
+    "checkJs": true,
     "noEmit": true
   },
   "include": ["src/*.js"]

--- a/typings/kavun/index.d.ts
+++ b/typings/kavun/index.d.ts
@@ -1,0 +1,1 @@
+declare module "kavun";


### PR DESCRIPTION
This PR sets up [TypeScript][1] for type-linting JS files. This project had a couple of JS files already but it was missing the type safety that a TypeScript might add. **Without moving to TypeScript I added type linting using TypeScript as a linter** on `*.js` files.
This PR contains a step by step introduction of TypeScript in this project, every commit explains what it does and if you want to learn how to add it to your project you can study commit by commit to see how you can add it to type-lint your JS files, without having to make them all `*.ts` files.

This PR contains the following:
1) **add TypeScript to the project**, including a npm-script to run it `npm run typecheck`
2) **configure TypeScript**, so it allows JS files to be found ([the commit][2]) and type checks JS files ([the commit][3])
3) **include existing type definitions of 3rd parties**, by adding a dependency `@types/*` to make TypeScript find type definition ([the commit][3])
4) **add custom type declaration for a 3rd party**, some 3rd parties do not (yet) provide type definitions, see in [this commit][4] how to do that
5) **add some typing to existing code**, in order to make proper use of TypeScript add some type definitions in the code (see [5] and [6])
6) **fix detected type errors** see [this commit][7]

[1]: https://www.typescriptlang.org/
[2]: https://github.com/wolframkriesing/to-do-list-checker/pull/2/commits/29d08b300a2b48d52e76a3f615d3707e9243ca96
[3]: https://github.com/wolframkriesing/to-do-list-checker/pull/2/commits/3dcfdd0bd525fd50ae70c9e7120d521bbc8ea754
[4]: https://github.com/wolframkriesing/to-do-list-checker/pull/2/commits/a6278134dd152de37af38afa9d3da2d545e9802f
[5]: https://github.com/wolframkriesing/to-do-list-checker/pull/2/commits/4a3c8016acd37ea0ee23c3d4f5f8d88446a9eff9
[6]: https://github.com/wolframkriesing/to-do-list-checker/pull/2/commits/1cb18611e15c9d0fbadcad16441c17d63a6faab6
[7]: https://github.com/wolframkriesing/to-do-list-checker/pull/2/commits/d5fc5aa9f0d88fae6fdcad33a2f782b4d3ac1fc6