### PR TITLE
Use Typescript for more explicit types (on *.js files)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [ ] rename the project to something more useful and shorter, easier to spell and remember, not even I can remember the name
 - [x] BUG: the nested items (see above) are not properly understood yet
 - [x] BUG: when `# version X` shows up like here, it makes the logic fail
+- [x] version can also be a string (like "1.0-beta"), not just a number (see type `TodoItems.version`)
 
 # version 4.0
 - [x] move to node v11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Ideas
 - [ ] add command to generate an example`CHANGELOG.md` file
 - [ ] add command to the according npm scripts, so releasing is made easy
+- [ ] typing: and/or maybe we want a `Result` returned from the parse function, which is either ok or not
+      instead of the `{version: -1}` as we have it now
 
 # version 5.0
 - [x] move development to use docker (nix is just not used anywhere by anyone)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@
   - [ ] the bug was not using `# version X` but `# vX` as headline, which is not really a bug
         show a warning and a hint when not finding the appropriate string
     - [x] prevent a parsing error to throw    
-  - [ ] to give the structure of the parsed text a meaning make it typed a bit better
-        maybe even use TS for typing and have a `Result` from the parsing process        
+  - [x] to give the structure of the parsed text a meaning make it typed a bit better
 - [ ] document usage in README
 - [ ] initialize CHANGELOG.md on first run
 - [ ] rename the project to something more useful and shorter, easier to spell and remember, not even I can remember the name

--- a/src/parse-changelog.d.ts
+++ b/src/parse-changelog.d.ts
@@ -1,5 +1,5 @@
 type TodoItems = {
-    version: number,
+    version: string,
     items: string[]
 }
 

--- a/src/parse-changelog.d.ts
+++ b/src/parse-changelog.d.ts
@@ -1,0 +1,7 @@
+type TodoItems = {
+    version: number,
+    items: string[]
+}
+
+export const LINE_START_FOR_TODO: string;
+export function parseChangelog(content: string): TodoItems;

--- a/src/parse-changelog.js
+++ b/src/parse-changelog.js
@@ -28,15 +28,15 @@ const todoItems = (content) => {
 export const parseChangelog = (changelogContent) => {
   const hasContent = !!changelogContent.trim();
   if (!hasContent) {
-    return { version: -1, items: [] };
+    return { version: '-1', items: [] };
   }
   const content = '\n' + changelogContent;
   const newLineAndNewVersionString = '\n' + LINE_START_FOR_NEW_VERSION;
   if (!content.includes(newLineAndNewVersionString)) {
-    return { version: -1, items: [] };
+    return { version: '-1', items: [] };
   }
   const versions = content.split(newLineAndNewVersionString);
   const firstVersionParagraph = versions[1];
-  const version = Number.parseInt(firstVersionParagraph.split('\n')[0], 10);
+  const version = firstVersionParagraph.split('\n')[0];
   return { version, items: todoItems(firstVersionParagraph) };
 };

--- a/src/parse-changelog.js
+++ b/src/parse-changelog.js
@@ -23,7 +23,7 @@ const todoItems = (content) => {
 
 /**
  * @param {string} changelogContent
- * @returns {{version: number, items: string[]}}
+ * @returns {import("./parse-changelog").TodoItems}
  */
 export const parseChangelog = (changelogContent) => {
   const hasContent = !!changelogContent.trim();


### PR DESCRIPTION
This PR introduces the first "complex" type into this project. It is basically a type made of two types.
This PR consists of:
1) **add a `*.d.ts` file** which contains the exported types of the `*.js` file
2) **use a type defined in the `*.d.ts` file** to not duplicate the types, see [this commit](https://github.com/wolframkriesing/to-do-list-checker/pull/3/commits/f2ac21ca3f0c92a9e2adebfc1f78810bc0773383)
3) **change one type and adjust the code**, see [this commit ](https://github.com/wolframkriesing/to-do-list-checker/pull/3/commits/788f2061df735c2ae788620755cbb0a2fd1da8fd)

Use `npm run typecheck` and `npm run test` to verify that all the code is valid.